### PR TITLE
Fix drag-scrolling under emulators, make hardware mice usable

### DIFF
--- a/app/src/main/cpp/Utils/imgui_androidbk/androidbk.cpp
+++ b/app/src/main/cpp/Utils/imgui_androidbk/androidbk.cpp
@@ -196,7 +196,7 @@ PRIVATE_API void initContext() {
 namespace CanvasInput {
 
 struct Event {
-    enum Kind { MousePos, MouseButton, Key, Char };
+    enum Kind { MousePos, MouseButton, MouseWheel, Key, Char };
     Kind     kind;
     float    x = 0.0f, y = 0.0f;
     int      code = 0;      // mouse button index, or Android keycode
@@ -230,6 +230,15 @@ static void PushMousePos(float x, float y) {
     Event e; e.kind = Event::MousePos; e.x = x; e.y = y;
     s_queue.push_back(e);
     s_lastX = x; s_lastY = y;
+}
+
+// Hardware-mouse wheel. Values arrive in Android axis convention straight
+// from GameActivity's ACTION_SCROLL case; the sign conversion to ImGui's
+// convention happens at replay time.
+static void PushMouseWheel(float x, float y) {
+    std::lock_guard<std::mutex> lk(s_queueMutex);
+    Event e; e.kind = Event::MouseWheel; e.x = x; e.y = y;
+    s_queue.push_back(e);
 }
 
 static void PushMouseButton(int button, bool down) {
@@ -346,6 +355,14 @@ static void Drain() {
             break;
         case Event::MouseButton:
             io.AddMouseButtonEvent(e.code, e.down);
+            break;
+        case Event::MouseWheel:
+            // Android AXIS_VSCROLL is positive scrolling up, matching
+            // AddMouseWheelEvent's wheel_y. AXIS_HSCROLL is positive to the
+            // right, while ImGui's wheel_x is positive scrolling LEFT - the
+            // same negation every desktop backend applies (imgui_impl_win32
+            // feeds WM_MOUSEHWHEEL as -delta).
+            io.AddMouseWheelEvent(-e.x, e.y);
             break;
         case Event::Key:
             io.AddKeyEvent(ImGui_ImplAndroid_KeyCodeToImGuiKey(e.code), e.down);
@@ -609,6 +626,11 @@ PRIVATE_API static void loadFonts(ImGuiIO& io, jfloat fontsize, AAssetManager *m
     io.Fonts->Build();
     if(fontBufferDroidSans != nullptr) free(fontBufferDroidSans);
 }
+
+// Defined in scroll.cpp: registers drag-to-scroll as an EndFramePre context
+// hook (why a context hook and not an inline hook: see scroll.cpp).
+PRIVATE_API void register_do_scroll(ImGuiContext *ctx);
+
 extern "C"
 JNIEXPORT void JNICALL
 Java_git_artdeell_skymodloader_ImGUI_init(JNIEnv *env, jclass clazz, jobject surface, jfloat fontsize, jfloat scale, jobject assetManager, jboolean enable_droid_sans) {
@@ -619,6 +641,10 @@ Java_git_artdeell_skymodloader_ImGUI_init(JNIEnv *env, jclass clazz, jobject sur
     method_setClipboard = env->GetStaticMethodID(clazz, "setClipboard", "(Ljava/lang/String;)V");
     method_getClipboard = env->GetStaticMethodID(clazz, "getClipboard", "()Ljava/lang/String;");
     ImGui::CreateContext();
+    // Needs the live context, and must precede renderloop() so no frame runs
+    // without it. Deliberately NOT in resurface(): that path reuses this
+    // context, and re-registering would double the hook.
+    register_do_scroll(ImGui::GetCurrentContext());
     ImGuiIO& io = ImGui::GetIO();
     io.IniFilename = nullptr;
     io.BackendPlatformName = "imgui4canvas";
@@ -653,6 +679,12 @@ JNIEXPORT void JNICALL
 Java_git_artdeell_skymodloader_ImGUI_submitButtonEvent(JNIEnv *env, jclass clazz, jint btn,
                                                        jboolean pressed) {
     CanvasInput::PushMouseButton(btn, pressed);
+}
+extern "C"
+JNIEXPORT void JNICALL
+Java_git_artdeell_skymodloader_ImGUI_submitScrollEvent(JNIEnv *env, jclass clazz, jfloat x,
+                                                       jfloat y) {
+    CanvasInput::PushMouseWheel(x, y);
 }
 extern "C"
 JNIEXPORT jboolean JNICALL

--- a/app/src/main/cpp/main.cpp
+++ b/app/src/main/cpp/main.cpp
@@ -30,7 +30,6 @@ extern "C" {
 
 static std::string g_skyBuildKey;
 
-void do_scroll();
 void fsel_setup(JNIEnv*);
 
 JNIEXPORT jint JNICALL JNI_OnLoad(JavaVM* vm, void* reserved) {
@@ -176,12 +175,6 @@ PRIVATE_API void Canvas::CanvasMenu() {
     //SystemsTest();
 }
 
-void (*ImGuiEnd)();
-void ImGuiEndHook() {
-    do_scroll();
-    return ImGuiEnd();
-}
-
 // Chat Record Constructor Hook (Sky 0.34.5) to fix blue messages bug without breaking permissions
 static void* (*orig_ChatRecordConstructor)(void*, void*, void*, void*, void*, void*, void*, void*) = nullptr;
 static void* g_chatRecordStub = nullptr;
@@ -244,10 +237,11 @@ int main() {
     do {
         sleep(1);
     } while (!Canvas::isLibLoaded(Canvas::libName));
-    (new CipherHook)->set_Hook((std::uintptr_t)ImGuiEndHook)
-    ->set_Callback((std::uintptr_t)&ImGuiEnd)
-    ->set_Address("_ZN5ImGui3EndEv")
-    ->Fire();
+    // Nothing below this wait depends on it any more (the ImGui::End inline
+    // hook it used to gate is gone; drag-to-scroll registers itself in
+    // androidbk's ImGUI_init - see scroll.cpp). It is kept because this
+    // constructor has always blocked until libBootloader is loaded, and
+    // changing that timing is a separate decision from moving the hook.
 
     install_chat_fix();
 

--- a/app/src/main/cpp/scroll.cpp
+++ b/app/src/main/cpp/scroll.cpp
@@ -1,24 +1,57 @@
 //
 // Created by maks on 06.12.2022.
 //
-#include <unordered_map>
 #include "Core/imgui/imgui_internal.h"
 #include "include/misc/visibility.h"
 
-PRIVATE_API void do_scroll() {
-    ImGuiContext &ctx = *ImGui::GetCurrentContext();
-    ImGuiWindow *window = ctx.CurrentWindow;
+// Drag-to-scroll, run once per frame as an EndFramePre context hook
+// (registered from androidbk's ImGUI_init, right after CreateContext).
+//
+// Deliberately NOT a runtime hook on ImGui::End: inline-patching a function
+// in our own statically linked binary is silently defeated by emulator ARM
+// translation caches (observed on MuMu - shadowhook reported success and the
+// hook body never executed, killing drag-to-scroll and letting scroll
+// gestures drag windows around instead). A context hook is plain compiled
+// code going through ImGui's own extension point, works under any
+// translation layer, and keeps the vendored imgui tree pristine.
+//
+// One call per frame on ctx.HoveredWindow covers every window:
+// ButtonBehavior's ItemHoverable requires g.HoveredWindow == window, so no
+// other window could ever act anyway. EndFramePre fires before
+// UpdateMouseMovingWindowEndFrame (see ImGui::EndFrame), so a press-frame
+// ActiveId claim here still suppresses ImGui's window-move for that click.
+static void do_scroll(ImGuiContext *ctx_, ImGuiContextHook *) {
+    ImGuiContext &ctx = *ctx_;
+    ImGuiWindow *window = ctx.HoveredWindow;
+    if (window == NULL || window->ScrollMax.y == 0 || ctx.HoveredId != 0)
+        return;
+    // ButtonBehavior reads GetCurrentWindow() for SetActiveID's owner window
+    // and the flatten-children check; point it at the window being scrolled
+    // for the duration. Plain assignment on purpose: SetCurrentWindow() is
+    // file-static inside imgui.cpp, and its font bookkeeping is not needed
+    // here - nothing is rendered.
+    ImGuiWindow *backup = ctx.CurrentWindow;
+    ctx.CurrentWindow = window;
     bool hovered = false, held = false;
-    ImVec2 &windowScrollMax = window->ScrollMax;
-    if (windowScrollMax.y != 0) {
-        if (ctx.HoveredId == 0) {
-            ImGui::ButtonBehavior(window->Rect(), window->GetID("###Canvas_scroll"), &hovered,
-                                  &held,
-                                  ImGuiButtonFlags_MouseButtonLeft);
-        }
-        if (hovered && !held) {
-            ImVec2 &mouseDelta = ImGui::GetIO().MouseDelta;
-            ImGui::SetScrollY(window, window->Scroll.y - mouseDelta.y);
-        }
+    // InnerClipRect, NOT Rect(): the claim must exclude the title bar and
+    // scrollbars, or title-bar presses get claimed as scrolls and the window
+    // can never be moved by drag.
+    ImGui::ButtonBehavior(window->InnerClipRect, window->GetID("###Canvas_scroll"),
+                          &hovered, &held, ImGuiButtonFlags_MouseButtonLeft);
+    // Scroll only while the primary button is held. A no-op for touch (a
+    // valid position implies a finger down), but a hardware mouse hovers
+    // with no button held, and without the gate every motion frame over
+    // claim-eligible space would scroll the content.
+    if (hovered && !held && ImGui::GetIO().MouseDown[0]) {
+        ImVec2 &mouseDelta = ImGui::GetIO().MouseDelta;
+        ImGui::SetScrollY(window, window->Scroll.y - mouseDelta.y);
     }
+    ctx.CurrentWindow = backup;
+}
+
+PRIVATE_API void register_do_scroll(ImGuiContext *ctx) {
+    ImGuiContextHook hook;
+    hook.Type = ImGuiContextHookType_EndFramePre;
+    hook.Callback = do_scroll;
+    ImGui::AddContextHook(ctx, &hook);
 }

--- a/app/src/main/java/com/tgc/sky/GameActivity.java
+++ b/app/src/main/java/com/tgc/sky/GameActivity.java
@@ -292,11 +292,27 @@ public class GameActivity extends TGCNativeActivity implements View.OnCapturedPo
         if (Build.VERSION.SDK_INT >= 30) setupDisplayListener();
     }
 
+    // Parity with stock Sky 0.34.5 (410941): the captured-pointer callback
+    // exists ONLY for Sony gamepad touchpads (button taps forwarded as key
+    // 0x6d at inputSource 1; touchpad MOTION is dropped, as in stock). ANY
+    // other captured device - a hardware mouse above all - releases capture
+    // immediately, so a mouse can never get stuck in relative mode: captured
+    // input bypasses the whole view tree, which would leave it click-dead
+    // and delta-driven for as long as capture held.
     @Override
     public boolean onCapturedPointer(View view, MotionEvent event) {
-        float dx = event.getX();
-        float dy = event.getY();
-        onMouseDeltaNative((int) dx, (int) -(dy));
+        if (isGamepadWithTouchpadEvent(event)) {
+            int vendorId = getDeviceVendorId(event);
+            int productId = getDeviceProductId(event);
+            int action = event.getAction();
+            if (action == MotionEvent.ACTION_BUTTON_PRESS) {
+                onButtonPress(0x6d, 1, true, vendorId, productId);
+            } else if (action == MotionEvent.ACTION_BUTTON_RELEASE) {
+                onButtonPress(0x6d, 1, false, vendorId, productId);
+            }
+        } else {
+            setPointerCapture(false);
+        }
         return true;
     }
 
@@ -681,6 +697,22 @@ public class GameActivity extends TGCNativeActivity implements View.OnCapturedPo
             motionEvent.getX(actionIndex), motionEvent.getY(actionIndex));
     }
 
+    // Hardware-mouse input for the ImGui overlay (no stock counterpart -
+    // stock has no overlay): feed the pointer exactly the way onTouchEvent
+    // feeds touches - bridge-view-relative coordinates into the same
+    // submitPositionEvent path, with ImGUI.wantsMouse() deciding whether the
+    // game sees the event at all.
+    private void submitImGuiMousePosition(MotionEvent motionEvent) {
+        float x = motionEvent.getX();
+        float y = motionEvent.getY();
+        if (imguiView != null) {
+            imguiView.getLocationOnScreen(m_imguiViewLocation);
+            x = motionEvent.getRawX() - m_imguiViewLocation[0];
+            y = motionEvent.getRawY() - m_imguiViewLocation[1];
+        }
+        ImGUI.submitPositionEvent(x, y);
+    }
+
     private PointF transformPointToProgram(float x, float y) {
         PointF p = new PointF();
         p.x = transformWidthToProgram(x);
@@ -709,6 +741,27 @@ public class GameActivity extends TGCNativeActivity implements View.OnCapturedPo
         if (isHardwareMouseEvent(motionEvent)) {
             if (isGamepadWithTouchpadEvent(motionEvent)) return true;
             PointF point = transformPointToProgram(motionEvent.getX(), motionEvent.getY());
+            // Mouse-to-ImGui: primary-button gestures mirror the touch path
+            // - position plus button 0 - and wantsMouse() then arbitrates
+            // ownership just like onTouchEvent does for touches. The
+            // backend's MouseDownOwned logic keeps a drag that began on the
+            // game out of ImGui and vice versa.
+            int actionMasked = motionEvent.getActionMasked();
+            if (actionMasked == MotionEvent.ACTION_DOWN
+                    || actionMasked == MotionEvent.ACTION_MOVE
+                    || actionMasked == MotionEvent.ACTION_UP) {
+                submitImGuiMousePosition(motionEvent);
+                if (actionMasked == MotionEvent.ACTION_DOWN) ImGUI.submitButtonEvent(0, true);
+                if (actionMasked == MotionEvent.ACTION_UP) ImGUI.submitButtonEvent(0, false);
+            }
+            if (ImGUI.wantsMouse()) {
+                // ImGui owns this gesture: the game sees neither the camera
+                // delta nor the cursor move. Still advance the delta anchor
+                // so the first game-owned event afterwards computes no
+                // spurious camera jump.
+                m_lastMouseLocation = point;
+                return true;
+            }
             if (motionEvent.getButtonState() == 1) {
                 float dx = (point.x - m_lastMouseLocation.x) * 3.0f;
                 float dy = -(point.y - m_lastMouseLocation.y) * 3.0f;
@@ -998,18 +1051,73 @@ public class GameActivity extends TGCNativeActivity implements View.OnCapturedPo
     public boolean onGenericMotionEvent(MotionEvent motionEvent) {
         if (this.m_motionEventsDisabled) return true;
         if (isHardwareMouseEvent(motionEvent)) {
-            int action = motionEvent.getActionMasked();
-            if (action == MotionEvent.ACTION_HOVER_MOVE
-                    || action == MotionEvent.ACTION_HOVER_ENTER
-                    || action == MotionEvent.ACTION_HOVER_EXIT) {
-                PointF point = transformPointToProgram(motionEvent.getX(), motionEvent.getY());
-                onMouseMoved((int) point.x, (int) point.y);
-                m_lastMouseLocation = point;
+            // Hardware-mouse dispatch, parity with stock Sky 0.34.5
+            // (410941): stock dispatches on the action and forwards mouse
+            // BUTTONS to the game (onButtonPress at inputSource 3) and one
+            // synthesized key tap per wheel notch, alongside hover and the
+            // scroll delta. Dropping the button cases means no
+            // hardware-mouse click ever reaches the game.
+            int vendorId = getDeviceVendorId(motionEvent);
+            int productId = getDeviceProductId(motionEvent);
+            if (isGamepadWithTouchpadEvent(motionEvent)) {
+                onGamepadConnected(vendorId, productId);
+                if (Build.VERSION.SDK_INT < 31) {
+                    onCapturedPointer(getBridgeView(), motionEvent);
+                }
                 return true;
             }
-            float scrollX = motionEvent.getAxisValue(MotionEvent.AXIS_HSCROLL);
-            float scrollY = motionEvent.getAxisValue(MotionEvent.AXIS_VSCROLL);
-            onMouseScrollingDelta(scrollX, scrollY);
+            // Mouse-to-ImGui: keep the overlay's pointer position fresh - it
+            // powers ImGui hover and the wantsMouse() ownership checks
+            // below. Button 0 itself is submitted from dispatchTouchEvent's
+            // DOWN/UP, which Android delivers alongside
+            // ACTION_BUTTON_PRESS/RELEASE for the primary button, so it is
+            // not repeated here.
+            submitImGuiMousePosition(motionEvent);
+            switch (motionEvent.getAction()) {
+                case MotionEvent.ACTION_HOVER_MOVE:
+                case MotionEvent.ACTION_HOVER_ENTER:
+                case MotionEvent.ACTION_HOVER_EXIT: {
+                    PointF point = transformPointToProgram(motionEvent.getX(), motionEvent.getY());
+                    onMouseMoved((int) point.x, (int) point.y);
+                    m_lastMouseLocation = point;
+                    break;
+                }
+                case MotionEvent.ACTION_SCROLL: {
+                    float scrollX = motionEvent.getAxisValue(MotionEvent.AXIS_HSCROLL);
+                    float scrollY = motionEvent.getAxisValue(MotionEvent.AXIS_VSCROLL);
+                    if (ImGUI.wantsMouse()) {
+                        // Over the overlay the wheel scrolls ImGui and never
+                        // reaches the game - no camera zoom behind the menu.
+                        ImGUI.submitScrollEvent(scrollX, scrollY);
+                        break;
+                    }
+                    // One synthesized key tap per notch, exactly as stock:
+                    // wheel down -> key 11, wheel up -> key 10, inputSource 3.
+                    int key = scrollY < 0.0f ? 11 : (scrollY > 0.0f ? 10 : 0);
+                    if (key != 0) {
+                        onButtonPress(key, 3, true, vendorId, productId);
+                        onButtonPress(key, 3, false, vendorId, productId);
+                    }
+                    onMouseScrollingDelta(scrollX, scrollY);
+                    break;
+                }
+                case MotionEvent.ACTION_BUTTON_PRESS:
+                    // wantsMouse() keeps clicks over the overlay away from
+                    // the game; a press that began on the game keeps its
+                    // release too (MouseDownOwned makes wantsMouse() stay
+                    // false for that whole drag, even ending over ImGui).
+                    if (!ImGUI.wantsMouse() && !isEventInTextField(motionEvent)) {
+                        onButtonPress(motionEvent.getActionButton(), 3, true, vendorId, productId);
+                    }
+                    break;
+                case MotionEvent.ACTION_BUTTON_RELEASE:
+                    if (!ImGUI.wantsMouse() && !isEventInTextField(motionEvent)) {
+                        onButtonPress(motionEvent.getActionButton(), 3, false, vendorId, productId);
+                    }
+                    break;
+                default:
+                    break;
+            }
             return true;
         }
         if (isGamepadEvent(motionEvent)) {

--- a/app/src/main/java/git/artdeell/skymodloader/ImGUI.java
+++ b/app/src/main/java/git/artdeell/skymodloader/ImGUI.java
@@ -45,6 +45,8 @@ public class ImGUI implements SurfaceHolder.Callback{
     public static native void shutdown();
     public static native void submitPositionEvent(float x, float y);
     public static native void submitButtonEvent(int btn, boolean pressed);
+    /** Mouse wheel notches, in Android axis convention (AXIS_HSCROLL/AXIS_VSCROLL). */
+    public static native void submitScrollEvent(float x, float y);
     public static native void submitUnicodeEvent(char codepoint);
     public static native void submitKeyEvent(int key, boolean down);
     /** End the active ImGui text-editing session, keeping whatever was typed. */


### PR DESCRIPTION
This started as a mod-side bug report ([Bad scrolling in MuMu Emulator - libtibik#28](https://github.com/HugeFrog24/libtibik/issues/28)) and turned out to be host-level.

In emulators, scroll gestures flung the window across the screen instead of scrolling, because the drag-to-scroll handler sat behind an inline hook that translation caches never execute. It now rides ImGui's own `EndFramePre` context hook (leaving the vendored imgui tree unpatched), and emulator scrolling works.

And hardware mice went from completely dead under Canvas (no clicks anywhere, pointer permanently latched into capture) to working on both the game and the overlay, wheel included.

## Discovered along the way

- **Inline hooks silently do nothing under emulator ARM translation** (MuMu's translator, houdini):
  - shadowhook reports success, the patched bytes never run, and nothing tells you. This likely reaches further than scrolling - `starwatch_block`'s dns/connect/sendto hooks and the fresh chat fix (0fd369e) use the same mechanism and may be quietly inert in emulators. Worth checking; the failure mode is invisible by design.
- **Sky's hover highlights track with inverted Y when you plug a USB mouse into a touchscreen phone running Canvas.**
  - Out of scope. That's a niche setup approximately nobody runs, so it's parked for a future aura-farming challenge. Fixing it earns pure tribute and serves a user base of roughly 0.

## Testing

Real device (touch + USB mouse) and MuMu Player, several build-and-retest cycles; stock Sky 0.34.5 (410941) used as the behavioral reference for the mouse paths.
